### PR TITLE
patch for sentry@0.3.20

### DIFF
--- a/plugins/sentry/package.json
+++ b/plugins/sentry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-sentry",
-  "version": "0.3.20",
+  "version": "0.3.20-gelato",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/sentry/src/plugin.ts
+++ b/plugins/sentry/src/plugin.ts
@@ -21,6 +21,7 @@ import {
   createPlugin,
   createRouteRef,
   discoveryApiRef,
+  identityApiRef,
 } from '@backstage/core-plugin-api';
 
 export const rootRouteRef = createRouteRef({
@@ -33,11 +34,12 @@ export const sentryPlugin = createPlugin({
   apis: [
     createApiFactory({
       api: sentryApiRef,
-      deps: { configApi: configApiRef, discoveryApi: discoveryApiRef },
-      factory: ({ configApi, discoveryApi }) =>
+      deps: { configApi: configApiRef, discoveryApi: discoveryApiRef, identityApi: identityApiRef },
+      factory: ({ configApi, discoveryApi, identityApi }) =>
         new ProductionSentryApi(
           discoveryApi,
           configApi.getString('sentry.organization'),
+          identityApi,
         ),
     }),
   ],


### PR DESCRIPTION
This PR shouldn't be merged to master, except locally to build an updated bundle.

the latest built bundle is here
https://rodiongork-genestack.github.io/backstage-plugins/patched-bundles/backstage-plugin-sentry-v0.3.20-gelato.tgz

**To build new bundle** please:

- check out this locally
- rebase (with master) and resolve conflicts (most probably version in package.json)
- update version in package.json so it differs
- execute `yarn build` and `yarn pack` in plugin folder
- commit the bundle to `gh-pages` branch

(obviously this could be made into CI job)